### PR TITLE
feat: add sign in and up in profile layout header while on view profile

### DIFF
--- a/src/components/layouts/profile.tsx
+++ b/src/components/layouts/profile.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import Link from 'next/link'
-import { UserButton, useAuth } from '@clerk/nextjs'
+import { Rocket } from 'lucide-react'
+import { UserButton, useAuth, SignedOut, SignUpButton, SignInButton } from '@clerk/nextjs'
+import { useRouter } from 'next/navigation'
 
+import { Button } from '@/components/ui/button'
 import { Mine } from '@/components/icons'
 import { ProfileProvider } from '@/components/profile/provider'
 import { ProfileWrapper } from '@/components/profile/wrapper'
@@ -20,6 +23,7 @@ export const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
 }
 
 const Header = () => {
+  const router = useRouter()
   const { isSignedIn } = useAuth()
 
   return (
@@ -39,7 +43,27 @@ const Header = () => {
               <UserButton />
             </div>
           </div>
-        ) : null}
+        ) : (
+          <div className='flex items-center gap-4 justify-between'>
+            <SignedOut>
+              <Button className='bg-sky-300' onClick={() => router.push('/explore')}>
+                <Rocket className='w-5 h-5' />
+                <span>Explore</span>
+              </Button>
+            </SignedOut>
+
+            <SignedOut>
+              <SignInButton>
+                <Button variant='neutral'>Sign In</Button>
+              </SignInButton>
+              <SignUpButton>
+                <Button className='transform -rotate-2 hover:rotate-0 transition-transform'>
+                  Sign Up
+                </Button>
+              </SignUpButton>
+            </SignedOut>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/src/components/layouts/root.tsx
+++ b/src/components/layouts/root.tsx
@@ -6,7 +6,7 @@ import { SignInButton, SignedOut, SignUpButton } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 
 import { Button } from '@/components/ui/button'
-import { Heart, Kinotio, Mine, Github } from '@/components/icons'
+import { Heart, Kinotio, Mine } from '@/components/icons'
 
 import { DATA } from '@/data'
 
@@ -51,12 +51,6 @@ const Header = () => {
             <Button className='bg-sky-300' onClick={() => router.push('/explore')}>
               <Rocket className='w-5 h-5' />
               <span>Explore</span>
-            </Button>
-          </SignedOut>
-
-          <SignedOut>
-            <Button variant='neutral'>
-              <Github />
             </Button>
           </SignedOut>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The header now presents a dedicated section for unauthenticated users featuring options to explore, sign in, or sign up.
	- The GitHub sign-out option has been removed from the header, resulting in a cleaner, more streamlined navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->